### PR TITLE
Update dependencies and code for scvi-tools >= 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.8", "3.9", "3.10"]
+                python-version: ["3.9", "3.10", "3.11"]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
     - repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 23.9.1
       hooks:
           - id: black
     - repo: https://github.com/PyCQA/flake8
-      rev: 4.0.1
+      rev: 6.1.0
       hooks:
           - id: flake8
     - repo: https://github.com/pycqa/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
             name: isort (python)

--- a/mrvi/_model.py
+++ b/mrvi/_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
 from typing import List, Optional
@@ -61,7 +63,7 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
 
     def __init__(
         self,
-        adata,
+        adata: AnnData,
         **model_kwargs,
     ):
         super().__init__(adata)
@@ -126,14 +128,14 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
 
     def train(
         self,
-        max_epochs: Optional[int] = None,
+        max_epochs: int | None = None,
         accelerator: str = "auto",
         devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
-        validation_size: Optional[float] = None,
+        validation_size: float | None = None,
         batch_size: int = 128,
         early_stopping: bool = False,
-        plan_kwargs: Optional[dict] = None,
+        plan_kwargs: dict | None = None,
         **trainer_kwargs,
     ):
         train_kwargs = dict(
@@ -156,10 +158,10 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
     @torch.no_grad()
     def get_latent_representation(
         self,
-        adata: Optional[AnnData] = None,
-        indices=None,
+        adata: AnnData | None = None,
+        indices: list[int] | None = None,
         mc_samples: int = 5000,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
         give_z: bool = False,
     ) -> np.ndarray:
         self._check_if_trained(warn=False)
@@ -205,10 +207,10 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
     @torch.no_grad()
     def get_local_sample_representation(
         self,
-        adata=None,
-        batch_size=256,
+        adata: AnnData | None = None,
+        batch_size: int = 256,
         mc_samples: int = 10,
-        return_distances=False,
+        return_distances: bool = False,
     ):
         """
         Computes the local sample representation of the cells in the adata object.

--- a/mrvi/_model.py
+++ b/mrvi/_model.py
@@ -17,7 +17,6 @@ from scvi.data.fields import (
 )
 from scvi.model.base import UnsupervisedTrainingMixin
 from scvi.model.base import BaseModelClass, VAEMixin
-from scvi.utils._docstrings import devices_dsp
 
 from ._module import MrVAE
 from ._constants import MRVI_REGISTRY_KEYS
@@ -130,7 +129,6 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
         adata_manager.register_fields(adata, **kwargs)
         cls.register_manager(adata_manager)
 
-    @devices_dsp
     def train(
         self,
         max_epochs: Optional[int] = None,

--- a/mrvi/_model.py
+++ b/mrvi/_model.py
@@ -17,6 +17,7 @@ from scvi.data.fields import (
 )
 from scvi.model.base import UnsupervisedTrainingMixin
 from scvi.model.base import BaseModelClass, VAEMixin
+from scvi.utils._docstrings import devices_dsp
 
 from ._module import MrVAE
 from ._constants import MRVI_REGISTRY_KEYS
@@ -129,10 +130,12 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
         adata_manager.register_fields(adata, **kwargs)
         cls.register_manager(adata_manager)
 
+    @devices_dsp
     def train(
         self,
         max_epochs: Optional[int] = None,
-        use_gpu: Optional[Union[str, int, bool]] = None,
+        accelerator: str = "auto",
+        devices: int | list[int] | str = "auto",
         train_size: float = 0.9,
         validation_size: Optional[float] = None,
         batch_size: int = 128,
@@ -142,7 +145,8 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
     ):
         train_kwargs = dict(
             max_epochs=max_epochs,
-            use_gpu=use_gpu,
+            accelerator=accelerator,
+            devices=devices,
             train_size=train_size,
             validation_size=validation_size,
             batch_size=batch_size,

--- a/mrvi/_model.py
+++ b/mrvi/_model.py
@@ -1,25 +1,19 @@
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from typing import List, Optional, Union
 
-from anndata import AnnData
 import numpy as np
 import torch
-from tqdm import tqdm
-from sklearn.metrics import pairwise_distances
-
+from anndata import AnnData
 from scvi import REGISTRY_KEYS
 from scvi.data import AnnDataManager
-from scvi.data.fields import (
-    CategoricalJointObsField,
-    CategoricalObsField,
-    LayerField,
-)
-from scvi.model.base import UnsupervisedTrainingMixin
-from scvi.model.base import BaseModelClass, VAEMixin
+from scvi.data.fields import CategoricalJointObsField, CategoricalObsField, LayerField
+from scvi.model.base import BaseModelClass, UnsupervisedTrainingMixin, VAEMixin
+from sklearn.metrics import pairwise_distances
+from tqdm import tqdm
 
-from ._module import MrVAE
 from ._constants import MRVI_REGISTRY_KEYS
+from ._module import MrVAE
 
 logger = logging.getLogger(__name__)
 

--- a/mrvi/_model.py
+++ b/mrvi/_model.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import logging
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from anndata import AnnData
 import numpy as np
@@ -43,7 +43,8 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
     Parameters
     ----------
     adata
-        AnnData object that has been registered via :meth:`~scvi.model.MrVI.setup_anndata`.
+        AnnData object that has been registered via
+        :meth:`~scvi.model.MrVI.setup_anndata`.
     n_latent
         Dimensionality of the latent space.
     n_latent_donor
@@ -195,7 +196,8 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
         Parameters
         ----------
         representations
-            Counterfactual sample representations of shape (n_cells, n_sample, n_features).
+            Counterfactual sample representations of shape
+            (n_cells, n_sample, n_features).
         metric
             Metric to use for computing distance matrix.
         """
@@ -226,7 +228,8 @@ class MrVI(UnsupervisedTrainingMixin, VAEMixin, BaseModelClass):
         batch_size
             Batch size to use for computing the local sample representation.
         mc_samples
-            Number of Monte Carlo samples to use for computing the local sample representation.
+            Number of Monte Carlo samples to use for computing the local sample
+            representation.
         return_distances
             If ``return_distances`` is ``True``, returns a distance matrix of
             size (n_sample, n_sample) for each cell.

--- a/mrvi/_module.py
+++ b/mrvi/_module.py
@@ -2,7 +2,7 @@ import torch
 import torch.distributions as db
 import torch.nn as nn
 from scvi import REGISTRY_KEYS
-from scvi.module.base import BaseModuleClass, LossRecorder, auto_move_data
+from scvi.module.base import BaseModuleClass, LossOutput, auto_move_data
 from scvi.nn import one_hot
 from torch.distributions import kl_divergence as kl
 
@@ -206,9 +206,10 @@ class MrVAE(BaseModuleClass):
 
         kl_local = torch.tensor(0.0)
         kl_global = torch.tensor(0.0)
-        return LossRecorder(
-            loss,
-            reconstruction_loss,
-            kl_local,
-            kl_global,
+
+        return LossOutput(
+            loss=loss,
+            reconstruction_loss=reconstruction_loss,
+            kl_local=kl_local,
+            kl_global=kl_global,
         )

--- a/mrvi/_module.py
+++ b/mrvi/_module.py
@@ -7,8 +7,8 @@ from scvi.nn import one_hot
 from torch.distributions import kl_divergence as kl
 
 from ._components import DecoderUZ, DecoderZX, LinearDecoderUZ
-from ._utils import ConditionalBatchNorm1d, NormalNN
 from ._constants import MRVI_REGISTRY_KEYS
+from ._utils import ConditionalBatchNorm1d, NormalNN
 
 DEFAULT_PX_HIDDEN = 32
 DEFAULT_PZ_LAYERS = 1
@@ -179,7 +179,6 @@ class MrVAE(BaseModuleClass):
         library,
         nuisance_oh,
     ):
-
         inputs = torch.concat([z, nuisance_oh], dim=-1)
         px = self.px(inputs, size_factor=library.exp())
         h = px.mu / library.exp()
@@ -194,7 +193,6 @@ class MrVAE(BaseModuleClass):
         generative_outputs,
         kl_weight: float = 1.0,
     ):
-
         reconstruction_loss = (
             -generative_outputs["px"].log_prob(tensors[REGISTRY_KEYS.X_KEY]).sum(-1)
         )

--- a/mrvi/_module.py
+++ b/mrvi/_module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import torch
 import torch.distributions as db
 import torch.nn as nn
@@ -18,18 +20,18 @@ DEFAULT_PZ_HIDDEN = 32
 class MrVAE(BaseModuleClass):
     def __init__(
         self,
-        n_input,
-        n_sample,
-        n_obs_per_sample,
-        n_cats_per_nuisance_keys,
-        n_latent=10,
-        n_latent_sample=2,
-        linear_decoder_zx=True,
-        linear_decoder_uz=True,
-        linear_decoder_uz_scaler=False,
-        linear_decoder_uz_scaler_n_hidden=32,
-        px_kwargs=None,
-        pz_kwargs=None,
+        n_input: int,
+        n_sample: int,
+        n_obs_per_sample: int,
+        n_cats_per_nuisance_keys: list[int],
+        n_latent: int = 10,
+        n_latent_sample: int = 2,
+        linear_decoder_zx: bool = True,
+        linear_decoder_uz: bool = True,
+        linear_decoder_uz_scaler: bool = False,
+        linear_decoder_uz_scaler_n_hidden: int = 32,
+        px_kwargs: dict | None = None,
+        pz_kwargs: dict | None = None,
     ):
         super().__init__()
         px_kwargs = dict(n_hidden=DEFAULT_PX_HIDDEN)
@@ -79,7 +81,9 @@ class MrVAE(BaseModuleClass):
         self.x_featurizer2 = nn.Sequential(nn.Linear(128, 128), nn.ReLU())
         self.bnn2 = ConditionalBatchNorm1d(128, n_sample)
 
-    def _get_inference_input(self, tensors, **kwargs):
+    def _get_inference_input(
+        self, tensors: dict[str, torch.Tensor], **kwargs
+    ) -> dict[str, torch.Tensor]:
         x = tensors[REGISTRY_KEYS.X_KEY]
         sample_index = tensors[MRVI_REGISTRY_KEYS.SAMPLE_KEY]
         categorical_nuisance_keys = tensors[
@@ -94,13 +98,13 @@ class MrVAE(BaseModuleClass):
     @auto_move_data
     def inference(
         self,
-        x,
-        sample_index,
-        categorical_nuisance_keys,
-        mc_samples=1,
-        cf_sample=None,
-        use_mean=False,
-    ):
+        x: torch.Tensor,
+        sample_index: torch.Tensor,
+        categorical_nuisance_keys: torch.Tensor,
+        mc_samples: int = 1,
+        cf_sample: torch.Tensor | None = None,
+        use_mean: bool = False,
+    ) -> dict[str, torch.Tensor]:
         x_ = torch.log1p(x)
 
         sample_index_cf = sample_index if cf_sample is None else cf_sample
@@ -153,7 +157,12 @@ class MrVAE(BaseModuleClass):
             nuisance_oh=nuisance_oh,
         )
 
-    def get_z(self, u, zsample=None, sample_index=None):
+    def get_z(
+        self,
+        u: torch.Tensor,
+        zsample: torch.Tensor | None = None,
+        sample_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         if sample_index is not None:
             zsample = self.sample_embeddings(sample_index.long().squeeze(-1))
             zsample = zsample
@@ -163,7 +172,12 @@ class MrVAE(BaseModuleClass):
         z = self.pz(inputs)
         return z
 
-    def _get_generative_input(self, tensors, inference_outputs, **kwargs):
+    def _get_generative_input(
+        self,
+        tensors: dict[str, torch.Tensor],
+        inference_outputs: dict[str, torch.Tensor],
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
         res = dict(
             z=inference_outputs["z"],
             library=inference_outputs["library"],
@@ -175,10 +189,10 @@ class MrVAE(BaseModuleClass):
     @auto_move_data
     def generative(
         self,
-        z,
-        library,
-        nuisance_oh,
-    ):
+        z: torch.Tensor,
+        library: torch.Tensor,
+        nuisance_oh: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
         inputs = torch.concat([z, nuisance_oh], dim=-1)
         px = self.px(inputs, size_factor=library.exp())
         h = px.mu / library.exp()
@@ -188,11 +202,11 @@ class MrVAE(BaseModuleClass):
 
     def loss(
         self,
-        tensors,
-        inference_outputs,
-        generative_outputs,
+        tensors: dict[str, torch.Tensor],
+        inference_outputs: dict[str, torch.Tensor],
+        generative_outputs: dict[str, torch.Tensor],
         kl_weight: float = 1.0,
-    ):
+    ) -> LossOutput:
         reconstruction_loss = (
             -generative_outputs["px"].log_prob(tensors[REGISTRY_KEYS.X_KEY]).sum(-1)
         )

--- a/mrvi/_utils.py
+++ b/mrvi/_utils.py
@@ -1,9 +1,8 @@
 import logging
 
 import torch
-import torch.nn as nn
 import torch.distributions as db
-
+import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ python-igraph = {version = "*", optional = true}
 scanpy = {version = ">=1.6", optional = true}
 scanpydoc = {version = ">=0.5", optional = true}
 scikit-misc = {version = ">=0.1.3", optional = true}
-scvi-tools = ">=0.17.0"
+scvi-tools = ">=1.0.0"
 sphinx = {version = ">=4.1,<4.4", optional = true}
 sphinx-autodoc-typehints = {version = "*", optional = true}
 sphinx-rtd-theme = {version = "*", optional = true}

--- a/tests/test_mrvi.py
+++ b/tests/test_mrvi.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from scvi.data import synthetic_iid
 
 from mrvi import MrVI

--- a/workflow/notebooks/semisynthetic.py
+++ b/workflow/notebooks/semisynthetic.py
@@ -15,7 +15,6 @@ from sklearn.metrics import pairwise_distances, precision_score, recall_score
 from statsmodels.stats.multitest import multipletests
 from tqdm import tqdm
 
-
 # %%
 workflow_dir = "../"
 base_dir = os.path.join(workflow_dir, "results/semisynthetic")
@@ -116,6 +115,8 @@ MODELS = [
     dict(model_name="CompositionSCVI", cell_specific=False),
     dict(model_name="MrVILinearLinear10", cell_specific=True),
 ]
+
+
 # %%
 def compute_aggregate_dmat(reps):
     n_cells, n_donors, _ = reps.shape

--- a/workflow/notebooks/semisynthetic.py
+++ b/workflow/notebooks/semisynthetic.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import plotnine as p9
 import scanpy as sc
+from scipy import stats
 from scipy.cluster.hierarchy import linkage, to_tree
 from sklearn.metrics import pairwise_distances, precision_score, recall_score
 from statsmodels.stats.multitest import multipletests
@@ -202,7 +203,7 @@ def linkage_to_ete(linkage_obj):
 # %%
 fig, ax = plt.subplots()
 im = ax.imshow(dissimilarity_mat)
-fig.savefig(os.path.join(figure_dir, f"CT B_GT_dist_matrix.svg"))
+fig.savefig(os.path.join(figure_dir, "CT B_GT_dist_matrix.svg"))
 plt.show()
 plt.close()
 # %%
@@ -305,7 +306,6 @@ for model in dist_mtxs:
 rf_df = pd.DataFrame(rf_df)
 
 # %%
-from scipy import stats
 
 for ct in [0, 1]:
     subs = rf_df.query(f"ct == '{ct}'")
@@ -441,7 +441,7 @@ fig = (
     + p9.scale_y_continuous(expand=(0, 0))
 )
 fig.save(
-    os.path.join(figure_dir, f"semisynth_TPR_comparison_synth.svg"),
+    os.path.join(figure_dir, "semisynth_TPR_comparison_synth.svg"),
 )
 fig
 
@@ -464,6 +464,6 @@ fig = (
     + p9.scale_y_continuous(expand=(0, 0))
 )
 fig.save(
-    os.path.join(figure_dir, f"semisynth_FDR_comparison_synth.svg"),
+    os.path.join(figure_dir, "semisynth_FDR_comparison_synth.svg"),
 )
 fig

--- a/workflow/notebooks/snrna.py
+++ b/workflow/notebooks/snrna.py
@@ -8,6 +8,7 @@ import pandas as pd
 import plotnine as p9
 import scanpy as sc
 import scipy.stats as stats
+from scib.metrics import silhouette, silhouette_batch
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import OneHotEncoder
 from tqdm import tqdm
@@ -417,8 +418,6 @@ for model_params in MODELS:
         d_ = pairwise_distances(x, metric=METRIC)
 
 # %%
-from scib.metrics import silhouette, silhouette_batch
-
 cell_reps = [
     "MrVILinearLinear10_cell",
     "SCVI_cell",

--- a/workflow/notebooks/snrna.py
+++ b/workflow/notebooks/snrna.py
@@ -8,11 +8,9 @@ import pandas as pd
 import plotnine as p9
 import scanpy as sc
 import scipy.stats as stats
-
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import OneHotEncoder
 from tqdm import tqdm
-
 
 METRIC = "euclidean"
 

--- a/workflow/notebooks/synthetic.py
+++ b/workflow/notebooks/synthetic.py
@@ -1,22 +1,20 @@
 # %%
-from collections import defaultdict
 import glob
 import os
-from itertools import product
 import re
+from collections import defaultdict
+from itertools import product
 
+import ete3
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scanpy as sc
-
-import matplotlib.pyplot as plt
 import seaborn as sns
-from tqdm import tqdm
-
-import ete3
-from scipy.spatial.distance import squareform
 from scipy.cluster.hierarchy import dendrogram, linkage, to_tree
+from scipy.spatial.distance import squareform
 from sklearn.metrics import pairwise_distances
+from tqdm import tqdm
 
 # %%
 workflow_dir = "../"
@@ -108,6 +106,7 @@ MODELS = [
     dict(model_name="MrVILinear50COMP", cell_specific=True),
 ]
 
+
 # %%
 def compute_aggregate_dmat(reps):
     # return pairwise_distances(reps.mean(0))
@@ -165,6 +164,7 @@ dist_mtxs["GroundTruth"] = [
     dict(dist_matrix=gt_dist_mtx, cats=gt_donor_combos, seed=None, ct="CT1:1"),
     dict(dist_matrix=gt_control_dist_mtx, cats=gt_donor_combos, seed=None, ct="CT2:1"),
 ]
+
 
 # %%
 # https://stackoverflow.com/questions/9364609/converting-ndarray-generated-by-hcluster-into-a-newick-string-for-use-with-ete2/17657426#17657426
@@ -295,12 +295,10 @@ fig.savefig(
 )
 plt.show()
 
+from sklearn.metrics import average_precision_score, precision_score
+
 # %%
 from statsmodels.stats.multitest import multipletests
-from sklearn.metrics import (
-    precision_score,
-    average_precision_score,
-)
 
 
 # %%

--- a/workflow/notebooks/synthetic.py
+++ b/workflow/notebooks/synthetic.py
@@ -12,8 +12,8 @@ import pandas as pd
 import scanpy as sc
 import seaborn as sns
 from scipy.cluster.hierarchy import dendrogram, linkage, to_tree
-from scipy.spatial.distance import squareform
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import average_precision_score, pairwise_distances, precision_score
+from statsmodels.stats.multitest import multipletests
 from tqdm import tqdm
 
 # %%
@@ -291,14 +291,9 @@ ax.set_ylabel("Model")
 ax.set_title("Robinson-Foulds Comparison to Ground Truth for Experimental Cell Type")
 fig.tight_layout()
 fig.savefig(
-    os.path.join(figure_dir, f"robinson_foulds_CT1:1_boxplot.svg"), bbox_inches="tight"
+    os.path.join(figure_dir, "robinson_foulds_CT1:1_boxplot.svg"), bbox_inches="tight"
 )
 plt.show()
-
-from sklearn.metrics import average_precision_score, precision_score
-
-# %%
-from statsmodels.stats.multitest import multipletests
 
 
 # %%

--- a/workflow/scripts/compute_local_scores.py
+++ b/workflow/scripts/compute_local_scores.py
@@ -1,18 +1,13 @@
 import logging
 from functools import partial
 
-import scanpy as sc
 import anndata as ad
-import torch
 import numpy as np
-from tqdm import tqdm
-
 import pynndescent
-
-from utils import (
-    compute_ks,
-    compute_manova,
-)
+import scanpy as sc
+import torch
+from tqdm import tqdm
+from utils import compute_ks, compute_manova
 
 
 def compute_autocorrelation_metric(

--- a/workflow/scripts/run_model.py
+++ b/workflow/scripts/run_model.py
@@ -1,17 +1,10 @@
 import logging
 import os
 
+import anndata as ad
 import numpy as np
 import scanpy as sc
-import anndata as ad
-
-from utils import (
-    PCAKNN,
-    CompositionBaseline,
-    MILO,
-    SCVIModel,
-    MrVIWrapper,
-)
+from utils import MILO, PCAKNN, CompositionBaseline, MrVIWrapper, SCVIModel
 
 profile = snakemake.config[snakemake.wildcards.dataset]
 N_EPOCHS = profile["nEpochs"]

--- a/workflow/scripts/utils/__init__.py
+++ b/workflow/scripts/utils/__init__.py
@@ -1,21 +1,20 @@
-from ._mrvi import MrVIWrapper
 from ._baselines import (
+    PCAKNN,
+    CompositionBaseline,
     CTypeProportions,
     PseudoBulkPCA,
     SCVIModel,
     StatifiedPseudoBulkPCA,
-    PCAKNN,
-    CompositionBaseline,
 )
-from ._milo import MILO
-
 from ._metrics import (
+    compute_cramers,
     compute_geary,
     compute_hotspot_morans,
-    compute_cramers,
     compute_ks,
     compute_manova,
 )
+from ._milo import MILO
+from ._mrvi import MrVIWrapper
 
 __all__ = [
     "MrVIWrapper",

--- a/workflow/scripts/utils/_baselines.py
+++ b/workflow/scripts/utils/_baselines.py
@@ -255,7 +255,6 @@ class PCAKNN(BaseModelClass):
 
 class SCVIModel(BaseModelClass):
     has_cell_representation = True
-    has_donor_representation = False
     has_local_donor_representation = True
     has_save = True
 

--- a/workflow/scripts/utils/_baselines.py
+++ b/workflow/scripts/utils/_baselines.py
@@ -1,13 +1,12 @@
 import numpy as np
 import pandas as pd
-from sklearn.decomposition import PCA
-import scanpy as sc
-from scvi.model import SCVI
-import torch
 import pynndescent
-from tqdm import tqdm
+import scanpy as sc
+import torch
 from scvi import REGISTRY_KEYS
-
+from scvi.model import SCVI
+from sklearn.decomposition import PCA
+from tqdm import tqdm
 
 from ._base_model import BaseModelClass
 

--- a/workflow/scripts/utils/_metrics.py
+++ b/workflow/scripts/utils/_metrics.py
@@ -1,11 +1,11 @@
-import torch
-from sklearn.preprocessing import OneHotEncoder
 import numpy as np
 import pandas as pd
 import scipy.stats as stats
-from statsmodels.multivariate.manova import MANOVA
 import statsmodels.api as sm
+import torch
 from joblib import Parallel, delayed
+from sklearn.preprocessing import OneHotEncoder
+from statsmodels.multivariate.manova import MANOVA
 
 
 def smooth_distance(sq_dists, mask_farther_than_k=False):

--- a/workflow/scripts/utils/_milo.py
+++ b/workflow/scripts/utils/_milo.py
@@ -1,5 +1,5 @@
-from scvi.model import SCVI
 import scanpy as sc
+from scvi.model import SCVI
 
 from ._base_model import BaseModelClass
 
@@ -42,11 +42,7 @@ class MILO(BaseModelClass):
             batch_key = self.categorical_nuisance_keys[0]
             adata_.obs[batch_key] = adata_.obs[batch_key].astype("category")
             for batch_cat in adata_.obs[batch_key].cat.categories.tolist():
-                alldata.append(
-                    adata_[
-                        adata_.obs[batch_key] == batch_cat,
-                    ]
-                )
+                alldata.append(adata_[adata_.obs[batch_key] == batch_cat,])
 
             cdata = sc.external.pp.mnn_correct(
                 *alldata, svd_dim=50, batch_key=batch_key, n_jobs=8

--- a/workflow/scripts/utils/_mrvi.py
+++ b/workflow/scripts/utils/_mrvi.py
@@ -1,9 +1,11 @@
-from mrvi import MrVI
-from ._base_model import BaseModelClass
+import numpy as np
 import pandas as pd
 import torch
-import numpy as np
 from tqdm import tqdm
+
+from mrvi import MrVI
+
+from ._base_model import BaseModelClass
 
 
 class MrVIWrapper(BaseModelClass):


### PR DESCRIPTION
- Closes #8
- Adds support for scvi-tools >= 1.0.0
- Switches from deprecated `use_gpu` to `accelerator` and `devices`
- Adds typing for model and module files
- Updates test workflow for Python 3.9 - 3.11
- Updates pre-commit versions